### PR TITLE
bugfix (be07cde) and possibility to configure redis settings (d267c76)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ npm install feathers-hooks-rediscache --save
 ```
 
 ## Purpose
-The purpose of these hooks is to provide redis caching for APIs endpoints. 
+The purpose of these hooks is to provide redis caching for APIs endpoints.
 
 Each request to an endpoint can be cached. Route variables and params are cached on a per request base. If a param to call is set to true and then to false to responses will be cached.
 
@@ -25,7 +25,7 @@ In the same fashion if you have many variants of the same endpoint that return s
 /articles/article?markdown=true // variant
 ```
 
-These are all listed in a redis list under `group-articles` and can be busted by calling `/cache/clear/group/article` or `/cache/clear/group/articles` it does not matter. All urls will be purged. 
+These are all listed in a redis list under `group-articles` and can be busted by calling `/cache/clear/group/article` or `/cache/clear/group/articles` it does not matter. All urls will be purged.
 
 It was meant to be used over http, not tested with sockets.
 
@@ -42,7 +42,7 @@ Available routes:
 
 ## Complete Example
 
-Here's an example of a Feathers server that uses `feathers-hooks-rediscache`. 
+Here's an example of a Feathers server that uses `feathers-hooks-rediscache`.
 
 ```js
 const feathers = require('feathers');
@@ -51,11 +51,13 @@ const hooks = require('feathers-hooks');
 const bodyParser = require('body-parser');
 const errorHandler = require('feathers-errors/handler');
 const routes = require('feathers-hooks-rediscache').cacheRoutes;
+const redisClient = require('feathers-hooks-rediscache').redisClient;
 
 // Initialize the application
 const app = feathers()
   .configure(rest())
   .configure(hooks())
+  .configure(redisClient)
   // Needed for parsing bodies (login)
   .use(bodyParser.json())
   .use(bodyParser.urlencoded({ extended: true }))
@@ -112,9 +114,23 @@ module.exports = {
 * the duration is in seconds and will automatically expire
 * you may just use `cache()` without specifying a duration, any request will be cached for a day
 
+
+To configure the redis connection the feathers configuration system can be used.
+```js
+//config/default.json
+{
+  "host": "localhost",
+  "port": 3030,
+  "redis": {
+    "host": "my-redis-service.example.com",
+    "port": 1234
+  }
+}
+```
+* if no config is provided, default config from the [redis module](https://github.com/NodeRedis/node_redis) is used
+
 ## to does
 * add configuration for the default duration
-* add configuration for the redis db (now using defaults) 
 
 ## License
 

--- a/src/hooks/cache.js
+++ b/src/hooks/cache.js
@@ -18,3 +18,14 @@ export function cache(options) { // eslint-disable-line no-unused-vars
     return Promise.resolve(hook);
   };
 };
+
+export function removeCacheInformation(options) { // eslint-disable-line no-unused-vars
+  options = Object.assign({}, defaults, options);
+
+  return function (hook) {
+    if (hook.result.hasOwnProperty('cache')) {
+      delete hook.result.cache;
+    }
+    return Promise.resolve(hook);
+  };
+};

--- a/src/hooks/redis.js
+++ b/src/hooks/redis.js
@@ -1,10 +1,8 @@
 
 import qs from 'querystring';
 import moment from 'moment';
-import redis from 'redis';
 import chalk from 'chalk';
 
-const client = redis.createClient();
 const defaults = {};
 
 export function before(options) { // eslint-disable-line no-unused-vars
@@ -13,6 +11,7 @@ export function before(options) { // eslint-disable-line no-unused-vars
   return function (hook) {
     return new Promise(resolve => {
       const q = hook.params.query || {};
+      let client = hook.app.get('redisClient');
       let path = '';
 
       if (!hook.id && Object.keys(q).length === 0) {
@@ -51,6 +50,7 @@ export function after(options) { // eslint-disable-line no-unused-vars
     return new Promise(resolve => {
       if (!hook.result.cache.cached) {
         const q = hook.params.query || {};
+        let client = hook.app.get('redisClient');
         let path = '';
 
         if (!hook.id && Object.keys(q).length === 0) {

--- a/src/hooks/redis.js
+++ b/src/hooks/redis.js
@@ -12,14 +12,15 @@ export function before(options) { // eslint-disable-line no-unused-vars
 
   return function (hook) {
     return new Promise(resolve => {
+      const q = hook.params.query || {};
       let path = '';
 
-      if (!hook.id && Object.keys(hook.params.query).length === 0) {
+      if (!hook.id && Object.keys(q).length === 0) {
         path = `${hook.path}`;
-      } else if (!hook.id && Object.keys(hook.params.query).length > 0) {
-        path = `${hook.path}?${qs.stringify(hook.params.query)}`;
-      } else if (hook.id && Object.keys(hook.params.query).length > 0) {
-        path = `${hook.id}?${qs.stringify(hook.params.query)}`;
+      } else if (!hook.id && Object.keys(q).length > 0) {
+        path = `${hook.path}?${qs.stringify(q)}`;
+      } else if (hook.id && Object.keys(q).length > 0) {
+        path = `${hook.id}?${qs.stringify(q)}`;
       } else {
         path = `${hook.id}`;
       }
@@ -49,7 +50,7 @@ export function after(options) { // eslint-disable-line no-unused-vars
   return function (hook) {
     return new Promise(resolve => {
       if (!hook.result.cache.cached) {
-        const q = hook.params.query;
+        const q = hook.params.query || {};
         let path = '';
 
         if (!hook.id && Object.keys(q).length === 0) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,11 @@
 import cacheRoutes from './routes/cache';
+import redisClient from './redisClient';
 import { cache as hookCache } from './hooks/cache';
 import { before as redisBeforeHook} from './hooks/redis';
 import { after as redisAfterHook} from './hooks/redis';
 
 export {
+  redisClient,
   cacheRoutes,
   hookCache,
   redisBeforeHook,

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import cacheRoutes from './routes/cache';
 import redisClient from './redisClient';
 import { cache as hookCache } from './hooks/cache';
+import { removeCacheInformation as hookRemoveCacheInformation } from './hooks/cache';
 import { before as redisBeforeHook} from './hooks/redis';
 import { after as redisAfterHook} from './hooks/redis';
 
@@ -8,6 +9,7 @@ export {
   redisClient,
   cacheRoutes,
   hookCache,
+  hookRemoveCacheInformation,
   redisBeforeHook,
   redisAfterHook
 };

--- a/src/redisClient.js
+++ b/src/redisClient.js
@@ -1,0 +1,5 @@
+import redis from 'redis';
+
+export default function redisClient() { // eslint-disable-line no-unused-vars
+  this.set('redisClient', redis.createClient(this.get('redis')));
+}

--- a/test/redis-after.test.js
+++ b/test/redis-after.test.js
@@ -19,6 +19,11 @@ describe('Redis After Hook', () => {
           cached: false,
           duration: 8400
         }
+      },
+      app: {
+        get: (what) => {
+          return client;
+        }
       }
     };
 
@@ -46,6 +51,11 @@ describe('Redis After Hook', () => {
         cache: {
           cached: false,
           duration: 8400
+        }
+      },
+      app: {
+        get: (what) => {
+          return client;
         }
       }
     };
@@ -75,6 +85,11 @@ describe('Redis After Hook', () => {
           cached: false,
           duration: 8400
         }
+      },
+      app: {
+        get: (what) => {
+          return client;
+        }
       }
     };
 
@@ -103,6 +118,11 @@ describe('Redis After Hook', () => {
           cached: false,
           duration: 8400
         }
+      },
+      app: {
+        get: (what) => {
+          return client;
+        }
       }
     };
 
@@ -129,6 +149,11 @@ describe('Redis After Hook', () => {
         },
         cache: {
           cached: false
+        }
+      },
+      app: {
+        get: (what) => {
+          return client;
         }
       }
     };

--- a/test/redis-before.test.js
+++ b/test/redis-before.test.js
@@ -65,7 +65,12 @@ describe('Redis Before Hook', () => {
     const mock = {
       params: { query: ''},
       path: '',
-      id: 'before-test-route'
+      id: 'before-test-route',
+      app: {
+        get: (what) => {
+          return client;
+        }
+      }
     };
 
     return hook(mock).then(result => {
@@ -80,7 +85,12 @@ describe('Redis Before Hook', () => {
     const mock = {
       params: { query: { full: true }},
       path: '',
-      id: 'before-test-route'
+      id: 'before-test-route',
+      app: {
+        get: (what) => {
+          return client;
+        }
+      }
     };
 
     return hook(mock).then(result => {
@@ -95,7 +105,12 @@ describe('Redis Before Hook', () => {
     const mock = {
       params: { query: ''},
       path: 'before-parent-route',
-      id: ''
+      id: '',
+      app: {
+        get: (what) => {
+          return client;
+        }
+      }
     };
 
     return hook(mock).then(result => {
@@ -110,7 +125,12 @@ describe('Redis Before Hook', () => {
     const mock = {
       params: { query: { full: true }},
       path: 'before-parent-route',
-      id: ''
+      id: '',
+      app: {
+        get: (what) => {
+          return client;
+        }
+      }
     };
 
     return hook(mock).then(result => {
@@ -125,7 +145,12 @@ describe('Redis Before Hook', () => {
     const mock = {
       params: { query: { full: true }},
       path: 'does-nothing',
-      id: ''
+      id: '',
+      app: {
+        get: (what) => {
+          return client;
+        }
+      }
     };
 
     return hook(mock).then(result => {


### PR DESCRIPTION
commit be07cde fixes an issue when `hook.params is empty` (and therefore hook.params.query cannot be converted into an object)

commit d267c76 fixes #2 partially. Partially because I was not able to pass the `redisClient` to the cache routes. Probably if one migrates the express routes to a feathers service, one can add a `.setup(app)` method to the service and get the redisClient from there.


