### PR TITLE
add parent to redis key in every case, bugfix duration

### DIFF
--- a/src/hooks/redis.js
+++ b/src/hooks/redis.js
@@ -64,7 +64,7 @@ export function after(options) { // eslint-disable-line no-unused-vars
         Object.assign(hook.result.cache, {
           cached: true,
           duration: duration,
-          expiresOn: moment().add(moment.duration(duration)),
+          expiresOn: moment().add(moment.duration(duration, 'seconds')),
           parent: hook.path,
           group: `group-${hook.path}`,
           key: path

--- a/src/hooks/redis.js
+++ b/src/hooks/redis.js
@@ -76,7 +76,7 @@ export function after(options) { // eslint-disable-line no-unused-vars
         if (process.env.NODE_ENV !== 'test') {
           console.log(
             `${chalk.cyan('[redis]')} added ${chalk.green(path)} to the cache.
-            Expires in ${moment.duration(duration).humanize()}.`);
+            Expires in ${moment.duration(duration, 'seconds').humanize()}.`);
         }
       }
       resolve(hook);

--- a/src/hooks/redis.js
+++ b/src/hooks/redis.js
@@ -12,16 +12,14 @@ export function before(options) { // eslint-disable-line no-unused-vars
     return new Promise(resolve => {
       const q = hook.params.query || {};
       let client = hook.app.get('redisClient');
-      let path = '';
+      let path = `${hook.path}`;
 
-      if (!hook.id && Object.keys(q).length === 0) {
-        path = `${hook.path}`;
-      } else if (!hook.id && Object.keys(q).length > 0) {
-        path = `${hook.path}?${qs.stringify(q)}`;
+      if (!hook.id && Object.keys(q).length > 0) {
+        path += `?${qs.stringify(q)}`;
       } else if (hook.id && Object.keys(q).length > 0) {
-        path = `${hook.id}?${qs.stringify(q)}`;
-      } else {
-        path = `${hook.id}`;
+        path += `/${hook.id}?${qs.stringify(q)}`;
+      } else if (hook.id && Object.keys(q).length === 0) {
+        path += `/${hook.id}`;
       }
 
       client.get(path, (err, reply) => {
@@ -51,16 +49,14 @@ export function after(options) { // eslint-disable-line no-unused-vars
       if (!hook.result.cache.cached) {
         const q = hook.params.query || {};
         let client = hook.app.get('redisClient');
-        let path = '';
+        let path = `${hook.path}`;
 
-        if (!hook.id && Object.keys(q).length === 0) {
-          path = `${hook.path}`;
-        } else if (!hook.id && Object.keys(q).length > 0) {
-          path = `${hook.path}?${qs.stringify(q)}`;
+        if (!hook.id && Object.keys(q).length > 0) {
+          path += `?${qs.stringify(q)}`;
         } else if (hook.id && Object.keys(q).length > 0) {
-          path = `${hook.id}?${qs.stringify(q)}`;
-        } else {
-          path = `${hook.id}`;
+          path += `/${hook.id}?${qs.stringify(q)}`;
+        } else if (hook.id && Object.keys(q).length === 0) {
+          path += `/${hook.id}`;
         }
         const duration = hook.result.cache.duration || 3600 * 24;
 

--- a/test/redis-after.test.js
+++ b/test/redis-after.test.js
@@ -6,6 +6,39 @@ import { redisAfterHook as a } from '../src';
 const client = redis.createClient();
 
 describe('Redis After Hook', () => {
+  it('caches a route', () => {
+    const hook = a();
+    const mock = {
+      params: { query: ''},
+      id: 'test-route',
+      path: '',
+      result: {
+        _sys: {
+          status: 200
+        },
+        cache: {
+          cached: false,
+          duration: 8400
+        }
+      },
+      app: {
+        get: (what) => {
+          return client;
+        }
+      }
+    };
+
+    return hook(mock).then(result => {
+      const data = result.result;
+
+      expect(data.cache.cached).to.equal(true);
+      expect(data.cache.duration).to.equal(8400);
+      expect(data.cache.parent).to.equal('');
+      expect(data.cache.group).to.equal('');
+      expect(data.cache.key).to.equal('test-route');
+    });
+  });
+
   it('caches a parent route', () => {
     const hook = a();
     const mock = {
@@ -100,7 +133,7 @@ describe('Redis After Hook', () => {
       expect(data.cache.duration).to.equal(8400);
       expect(data.cache.parent).to.equal('parent');
       expect(data.cache.group).to.equal('group-parent');
-      expect(data.cache.key).to.equal('test-route');
+      expect(data.cache.key).to.equal('parent/test-route');
     });
   });
 
@@ -133,7 +166,7 @@ describe('Redis After Hook', () => {
       expect(data.cache.duration).to.equal(8400);
       expect(data.cache.parent).to.equal('parent');
       expect(data.cache.group).to.equal('group-parent');
-      expect(data.cache.key).to.equal('test-route?full=true');
+      expect(data.cache.key).to.equal('parent/test-route?full=true');
     });
   });
 
@@ -167,12 +200,12 @@ describe('Redis After Hook', () => {
   });
 
   after(() => {
-    client.del('parent');
-    client.del('parent?full=true');
-    client.del('test-route');
-    client.del('test-route?full=true');
-    client.del('group-test-route');
-    client.del('group-parent');
+    // client.del('parent');
+    // client.del('parent?full=true');
+    // client.del('test-route');
+    // client.del('test-route?full=true');
+    // client.del('group-test-route');
+    // client.del('group-parent');
   });
 
 });

--- a/test/redis-before.test.js
+++ b/test/redis-before.test.js
@@ -162,9 +162,9 @@ describe('Redis Before Hook', () => {
   });
 
   after(() => {
-    client.del('before-test-route');
-    client.del('before-test-route?full=true');
-    client.del('before-parent-route');
-    client.del('before-parent-route?full=true');
+    // client.del('before-test-route');
+    // client.del('before-test-route?full=true');
+    // client.del('before-parent-route');
+    // client.del('before-parent-route?full=true');
   });
 });


### PR DESCRIPTION
Caution: this is probably a breaking change! (especially routes were not tested)

- Commit 76a2e21f916d57bd214039da1a10972edd6df5c7 starts including the parent in the redis key for every case. I propose this change because until now, if you have an API with endpoints like this `<url>/articles/123` and `<url>/persons/123` the items get cached in the same key `123` (happened to me). This commit fixes this by including the parent in the key `persons/123`.
- Commit cfc986e6bafe764e43d19089815f2bb01ad319c7 basically fixes some edge case in the new behavior (only include slash in redis key if there is a parent at all)
- Commits 02fc95a748f6b41f93962d4af70870c4966a839c and 4d896948f5d3b6d3491f887c06b81754f26015ea fix issue #11 

I'm aware that this may change the usage of the hooks again a bit, but I'm confident that this change will lead to a more generally usable behavior of the hooks.
If you do not agree, feel free to reject the PR and explain why the algorithm for the redis key names works the way it works now. it is indeed possible that I missed something or did not understand all of the logic behind your code :-)
