### PR TITLE
add support for nested routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,18 +39,20 @@ A cache object can be added to the default feathers configuration
 ```js
   "redisCache" : {
     "defaultDuration": 3600,
+    "parseNestedRoutes": true,
     "removePathFromCacheKey": true
   };
 ```
-The default duration can be configured by passing the duration in seconds to the property `defualtDuration`.
-`removePathFromCacheKey` is an option that is useful when working with content and slugs. If when this option is turned on you can have the following issue. If your routes use IDs the you could have a conflict and the cache might return the wrong value:
+The default duration can be configured by passing the duration in seconds to the property `defaultDuration`.
+If your API uses nested routes like `/author/:authorId/book` you should turn on the option `parseNestedRoutes`. Otherwise you could have conflicting cache keys.
+`removePathFromCacheKey` is an option that is useful when working with content and slugs. If when this option is turned on you can have the following issue. If your routes use IDs then you could have a conflict and the cache might return the wrong value:
 
 ```
   user/123
   article/123
 ```
 
-both items with id `123` would be saved under the same cache key... thus replacing each other and returning one for the other, thus by default the key includes the path to diferenciate them. when working with content you could have an external system busting the cache that is not aware of your API routes. That system would know the slug, but cannot bust the cache as it would have to call `/cache/clear/single/:path/target`, with this option that system can simply call `:target` which would be the slug/alias of the article. 
+both items with id `123` would be saved under the same cache key... thus replacing each other and returning one for the other, thus by default the key includes the path to diferenciate them. when working with content you could have an external system busting the cache that is not aware of your API routes. That system would know the slug, but cannot bust the cache as it would have to call `/cache/clear/single/:path/target`, with this option that system can simply call `:target` which would be the slug/alias of the article.
 
 
 Available routes:

--- a/src/hooks/helpers/path.js
+++ b/src/hooks/helpers/path.js
@@ -1,9 +1,26 @@
 import qs from 'querystring';
 
+function parseNestedPath(path, params) {
+  let re = new RegExp(':([^\/]+)', 'g');
+  let match = null;
+
+  while ((match = re.exec(path)) !== null) {
+    if (Object.keys(params).includes(match[1])) {
+      path = path.replace(match[0], params[match[1]]);
+    }
+  }
+  return path;
+}
+
 function parsePath(hook, config) {
   const q = hook.params.query || {};
   const remove = config.removePathFromCacheKey || false;
+  const parseNestedRoutes = config.parseNestedRoutes || false;
   let path = remove && hook.id ? '' : `${hook.path}`;
+
+  if (!remove && parseNestedRoutes) {
+    path = parseNestedPath(path, hook.params);
+  }
 
   if (hook.id) {
     if (path.length !== 0 && !remove) {

--- a/test/redis-after.test.js
+++ b/test/redis-after.test.js
@@ -111,6 +111,89 @@ describe('Redis After Hook', () => {
     });
   });
 
+  it('caches a parent route with setting to remove path from key...', () => {
+    const hook = a();
+    const mock = {
+      params: { query: ''},
+      path: 'test-route',
+      result: {
+        _sys: {
+          status: 200
+        },
+        cache: {
+          cached: false,
+          duration: 8400
+        }
+      },
+      app: {
+        get: (what) => {
+          if (what === 'redisClient') return client;
+          if (what === 'redisCache') {
+            const cache = {
+              defaultDuration: 3600,
+              removePathFromCacheKey: true
+            };
+
+            return cache;
+          }
+          return undefined;
+        }
+      }
+    };
+
+    return hook(mock).then(result => {
+      const data = result.result;
+
+      expect(data.cache.cached).to.equal(true);
+      expect(data.cache.duration).to.equal(8400);
+      expect(data.cache.parent).to.equal('test-route');
+      expect(data.cache.group).to.equal('group-test-route');
+      expect(data.cache.key).to.equal('test-route');
+    });
+  });
+
+  it('caches a nested route with setting to parse it...', () => {
+    const hook = a();
+    const mock = {
+      params: { abcId: 123, query: ''},
+      path: 'test-route/:abcId',
+      id: 'nested-route',
+      result: {
+        _sys: {
+          status: 200
+        },
+        cache: {
+          cached: false,
+          duration: 8400
+        }
+      },
+      app: {
+        get: (what) => {
+          if (what === 'redisClient') return client;
+          if (what === 'redisCache') {
+            const cache = {
+              defaultDuration: 3600,
+              parseNestedRoutes: true
+            };
+
+            return cache;
+          }
+          return undefined;
+        }
+      }
+    };
+
+    return hook(mock).then(result => {
+      const data = result.result;
+
+      expect(data.cache.cached).to.equal(true);
+      expect(data.cache.duration).to.equal(8400);
+      expect(data.cache.parent).to.equal('test-route/:abcId');
+      expect(data.cache.group).to.equal('group-test-route/:abcId');
+      expect(data.cache.key).to.equal('test-route/123/nested-route');
+    });
+  });
+
   it('caches a parent with params', () => {
     const hook = a();
     const mock = {


### PR DESCRIPTION
when specified with the config option `parseNestedRoutes` placeholders in the `path` are replaced with its their actual values.
this prevents conflict for routes like `/author/:authorId/books` (without replacing `:authorId` books for different authors would be saved under the same key in redis).

(probably one should also parse the `parent` property, but this is not as important as the key itself)