### PR TITLE
bugfix: setup routes (and their redis client) on demand only

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ const app = feathers()
   .use(bodyParser.json())
   .use(bodyParser.urlencoded({ extended: true }))
   // add the cache routes (endpoints) to the app
-  .use('/cache', routes)
+  .use('/cache', routes())
   .use(errorHandler());
 
 app.listen(3030);

--- a/src/routes/cache.js
+++ b/src/routes/cache.js
@@ -2,62 +2,66 @@ import express from 'express';
 import redis from 'redis';
 import RedisCache from './helpers/redis';
 
-const router = express.Router();
-const client = redis.createClient();
-const h = new RedisCache(client);
+function routes() {
+  const router = express.Router();
+  const client = redis.createClient();
+  const h = new RedisCache(client);
 
-// adding some cache routes
+  // adding some cache routes
 
-router.get('/clear', (req, res) => {
-  client.flushall();
-  res.status(200).json({
-    message: 'Cache cleared'
-  });
-});
-
-// clear a unique route
-router.get('/clear/single/:target?', (req, res) => {
-  const t = req.url.split('/')[4];
-
-  if (t.includes('?')) {
-    h.clearSingle(t).then(r => {
-      res.status(200).json({
-        message: `cache ${r ? '' : 'already'} cleared for key (with params): ${t}`
-      });
-    });
-  } else {
-    h.clearSingle(req.params.target).then(r => {
-      res.status(200).json({
-        message: `cache ${r ? '' : 'already'} cleared for key (without params): ${req.params.target}`
-      });
-    });
-  }
-});
-
-// clear a group
-router.get('/clear/group/:target', (req, res) => {
-  client.get(`${req.params.target}`, (err, reply) => {
-    if (err) res.status(500).json({message: 'something went wrong'});
-    const group = reply ? JSON.parse(reply).cache.group : '';
-
-    h.clearGroup(group).then(r => {
-      res.status(200).json({
-        message: `cache ${r ? '' : 'already'} cleared for the group key: ${req.params.target}`
-      });
+  router.get('/clear', (req, res) => {
+    client.flushall();
+    res.status(200).json({
+      message: 'Cache cleared'
     });
   });
-});
 
-// add route to display cache index
-router.get('/index', (req, res) => {
-  h.scan()
-    .then(data => {
-      res.status(200).json(data);
-    })
-    .catch(err => {
-      res.status(404).json(err);
+  // clear a unique route
+  router.get('/clear/single/:target?', (req, res) => {
+    const t = req.url.split('/')[4];
+
+    if (t.includes('?')) {
+      h.clearSingle(t).then(r => {
+        res.status(200).json({
+          message: `cache ${r ? '' : 'already'} cleared for key (with params): ${t}`
+        });
+      });
+    } else {
+      h.clearSingle(req.params.target).then(r => {
+        res.status(200).json({
+          message: `cache ${r ? '' : 'already'} cleared for key (without params): ${req.params.target}`
+        });
+      });
+    }
+  });
+
+  // clear a group
+  router.get('/clear/group/:target', (req, res) => {
+    client.get(`${req.params.target}`, (err, reply) => {
+      if (err) res.status(500).json({message: 'something went wrong'});
+      const group = reply ? JSON.parse(reply).cache.group : '';
+
+      h.clearGroup(group).then(r => {
+        res.status(200).json({
+          message: `cache ${r ? '' : 'already'} cleared for the group key: ${req.params.target}`
+        });
+      });
     });
+  });
 
-});
+  // add route to display cache index
+  router.get('/index', (req, res) => {
+    h.scan()
+      .then(data => {
+        res.status(200).json(data);
+      })
+      .catch(err => {
+        res.status(404).json(err);
+      });
 
-export default router;
+  });
+
+  return router;
+}
+
+export default routes;


### PR DESCRIPTION
I encountered the problem, that if I have a non-default redis server (alternate port, ip, ...), feathers kept crashing because when requiring `feathers-hooks-rediscache` `routes/cache.js` is executed immediately (and it tries to create a redis connection on the default port, ip, ...).
So I put the setup of the routes in a function `routes`. The function returns the router so it can still be used as callback for feathers' `app.use()`.
Probably not the most elegant solution but it works (unfortunately with a change in the usage of the module).