### PR TITLE
Improve path parsing to include optional params on dynamic routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ These are all listed in a redis list under `group-articles` and can be busted by
 
 It was meant to be used over http, not yet tested with sockets.
 
-## Availabe hooks
+## Available hooks
 More details and example use bellow
 
 ### Before
@@ -180,4 +180,3 @@ Licensed under the [MIT license](LICENSE).
 
 ### v0.3.0
 * introduces a breaking change: `.use('/cache', routes(app))`
-

--- a/src/hooks/helpers/path.js
+++ b/src/hooks/helpers/path.js
@@ -1,8 +1,9 @@
 import qs from 'qs';
 
 function parseNestedPath(path, params) {
-  let re = new RegExp(':([^\/]+)', 'g');
+
   let match = null;
+  let re = new RegExp(':([^\\/\\?]+)\\??', 'g');
 
   while ((match = re.exec(path)) !== null) {
     if (Object.keys(params).includes(match[1])) {


### PR DESCRIPTION
### Summary
- Allows dynamic routes with params to be cached properly
- See #17 

### Other Information
This is a simple change to allow nested routes such as `author/:authorId?/book` to be handled properly. The question mark in these routes allows optional params in express and so the RegEx had to be tweaked to account for it.  It also fixes a tiny typo in the README. :)
