### PR TITLE
fix: Make nested routes compatible with Feathers 3

### DIFF
--- a/src/hooks/helpers/path.js
+++ b/src/hooks/helpers/path.js
@@ -5,10 +5,11 @@ function parseNestedPath(path, params) {
   let match = null;
 
   while ((match = re.exec(path)) !== null) {
-    if (Object.keys(params).includes(match[1])) {
-      path = path.replace(match[0], params[match[1]]);
+    if (Object.keys(params.route).includes(match[1])) {
+      path = path.replace(match[0], params.route[match[1]]);
     }
   }
+
   return path;
 }
 

--- a/test/redis-after.test.js
+++ b/test/redis-after.test.js
@@ -184,11 +184,16 @@ describe('Redis After Hook', () => {
       expect(data.cache.key).to.equal('test-route');
     });
   });
-  
+
   it('caches a nested route with setting to parse it...', () => {
     const hook = a();
     const mock = {
-      params: { abcId: 123, query: ''},
+      params: {
+        route: {
+          abcId: 123
+        },
+        query: ''
+      },
       path: 'test-route/:abcId',
       id: 'nested-route',
       result: {
@@ -230,7 +235,12 @@ describe('Redis After Hook', () => {
   it('caches a nested route with optional params set', () => {
     const hook = a();
     const mock = {
-      params: { abcId: 123, query: ''},
+      params: {
+        route: {
+          abcId: 123
+        },
+        query: ''
+      },
       path: 'test-route/:abcId?',
       id: 'nested-route',
       result: {
@@ -272,7 +282,12 @@ describe('Redis After Hook', () => {
   it('caches a route with optional params set,', () => {
     const hook = a();
     const mock = {
-      params: { abcId: 123, query: ''},
+      params: {
+        route: {
+          abcId: 123
+        },
+        query: ''
+      },
       path: 'test-route/:abcId?',
       id: '',
       result: {


### PR DESCRIPTION
This commit updates the parseNestedPath function to account for new
nested params in Feathers #3

See https://github.com/idealley/feathers-hooks-rediscache/issues/21