### PR TITLE
fix: handle redis connection errors

### DIFF
--- a/src/hooks/redis.js
+++ b/src/hooks/redis.js
@@ -54,7 +54,7 @@ export function after(options) { // eslint-disable-line no-unused-vars
       if (!hook.result.cache.cached) {
         const duration = hook.result.cache.duration || options.defaultDuration;
         const client = hook.app.get('redisClient');
-        
+
         if (!client) {
           resolve(hook);
         }

--- a/src/hooks/redis.js
+++ b/src/hooks/redis.js
@@ -15,6 +15,11 @@ export function before(options) { // eslint-disable-line no-unused-vars
 
     return new Promise(resolve => {
       const client = hook.app.get('redisClient');
+
+      if (!client) {
+        resolve(hook);
+      }
+
       const path = parsePath(hook, options);
 
       client.get(path, (err, reply) => {
@@ -49,6 +54,11 @@ export function after(options) { // eslint-disable-line no-unused-vars
       if (!hook.result.cache.cached) {
         const duration = hook.result.cache.duration || options.defaultDuration;
         const client = hook.app.get('redisClient');
+        
+        if (!client) {
+          resolve(hook);
+        }
+
         const path = parsePath(hook, options);
 
         // adding a cache object

--- a/src/redisClient.js
+++ b/src/redisClient.js
@@ -8,6 +8,7 @@ export default function redisClient() { // eslint-disable-line no-unused-vars
   const redisOptions = Object.assign({}, this.get('redis'), {
     retry_strategy: function (options) { // eslint-disable-line camelcase
       app.set('redisClient', undefined);
+      /* istanbul ignore next */
       if (cacheOptions.env !== 'test') {
         console.log(`${chalk.yellow('[redis]')} not connected`);
       }
@@ -20,6 +21,7 @@ export default function redisClient() { // eslint-disable-line no-unused-vars
 
   client.on('ready', () => {
     app.set('redisClient', client);
+    /* istanbul ignore next */
     if (cacheOptions.env !== 'test') {
       console.log(`${chalk.green('[redis]')} connected`);
     }

--- a/src/redisClient.js
+++ b/src/redisClient.js
@@ -16,6 +16,8 @@ export default function redisClient() { // eslint-disable-line no-unused-vars
   });
   const client = redis.createClient(redisOptions);
 
+  app.set('redisClient', client);
+
   client.on('ready', () => {
     app.set('redisClient', client);
     if (cacheOptions.env !== 'test') {

--- a/src/redisClient.js
+++ b/src/redisClient.js
@@ -2,7 +2,7 @@ import redis from 'redis';
 import chalk from 'chalk';
 
 export default function redisClient() { // eslint-disable-line no-unused-vars
-  const app = this;;
+  const app = this;
   const cacheOptions = app.get('redisCache') || {};
   const retryInterval = cacheOptions.retryInterval || 10000;
   const redisOptions = Object.assign({}, this.get('redis'), {

--- a/src/redisClient.js
+++ b/src/redisClient.js
@@ -1,6 +1,26 @@
 import redis from 'redis';
+import chalk from 'chalk';
 
 export default function redisClient() { // eslint-disable-line no-unused-vars
-  this.set('redisClient', redis.createClient(this.get('redis')));
+  const app = this;;
+  const cacheOptions = app.get('redisCache') || {};
+  const retryInterval = cacheOptions.retryInterval || 10000;
+  const redisOptions = Object.assign({}, this.get('redis'), {
+    retry_strategy: function (options) { // eslint-disable-line camelcase
+      app.set('redisClient', undefined);
+      if (cacheOptions.env !== 'test') {
+        console.log(`${chalk.yellow('[redis]')} not connected`);
+      }
+      return retryInterval;
+    }
+  });
+  const client = redis.createClient(redisOptions);
+
+  client.on('ready', () => {
+    app.set('redisClient', client);
+    if (cacheOptions.env !== 'test') {
+      console.log(`${chalk.green('[redis]')} connected`);
+    }
+  });
   return this;
 }

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -1,0 +1,33 @@
+import { expect } from 'chai';
+import RedisClient from '../src/redisClient';
+
+const app = {
+  get: function(key) {
+    return this[key];
+  },
+  set: function(key, val) {
+    this[key] = val;
+  },
+  configure: function(fn) {
+    fn.call(this);
+  }
+};
+
+describe('redisClient', () => {
+  it('should not exist if redis not connected', (done) => {
+    app.set('redis', { port: 1234 }); // force connection error
+    app.configure(RedisClient);
+    setTimeout(function () {
+      expect(app.get('redisClient')).to.not.exist;
+      done();
+    }, 500);
+  });
+  it('should be available if redis connected', (done) => {
+    app.set('redis', { port: 6379 }); // restore default
+    app.configure(RedisClient);
+    setTimeout(function () {
+      expect(app.get('redisClient')).to.exist;
+      done();
+    }, 500);
+  });
+});

--- a/test/hooks/redis-after.test.js
+++ b/test/hooks/redis-after.test.js
@@ -634,6 +634,41 @@ describe('Redis After Hook', () => {
     });
   });
 
+  it ('does not save anything in cache if redisClient offline', () => {
+    const hook = a();
+    const clientDummy = {
+      keys: [],
+      set: function(key, val) {
+        this.keys.push(key);
+      },
+      expire: function() {},
+      rpush: function() {},
+    };
+    const mock = {
+      params: { query: '' },
+      path: 'dummy',
+      id: 'do-not-save',
+      result: {
+        cache: {}
+      },
+      app: {
+        get: (what) => {
+          // comment in to emulate redisClient online (will cause test fail)
+          // if (what === 'redisClient') {
+          //   return clientDummy;
+          // }
+        }
+      }
+    };
+    const prevKeys = clientDummy.keys.join();
+
+    return hook(mock).then(result => {
+      const currKeys = clientDummy.keys.join();
+
+      expect(currKeys).to.equal(prevKeys);
+    });
+  });
+
   // after(() => {
   //   client.del('parent');
   //   client.del('parent?full=true');

--- a/test/hooks/redis-before.test.js
+++ b/test/hooks/redis-before.test.js
@@ -222,6 +222,24 @@ describe('Redis Before Hook', () => {
     });
   });
 
+  it('does not return any result if redisClient offline', () => {
+    const hook = b();
+    const mock = {
+      params: { query: ''},
+      path: '',
+      id: '',
+      app: {
+        get: (what) => {}
+      }
+    };
+
+    return hook(mock).then(result => {
+      const data = result.result;
+
+      expect(data).to.be.undefined;
+    });
+  });
+
   after(() => {
     client.del('before-test-route');
     client.del('before-test-route?full=true');


### PR DESCRIPTION
### Summary

(If you have not already please refer to the contributing guideline as [described
here](https://github.com/feathersjs/feathers/blob/master/.github/contributing.md#pull-requests))

- [x] Tell us about the problem your pull request is solving.
- [x] Are there any open issues that are related to this?
- [ ] Is this PR dependent on PRs in other repos?

If so, please mention them to keep the conversations linked together.

### Other Information

This PR fixes the bad or rather missing error handling of this hook when connection to redis is not possible.
First of all an error event listener was missing what threw an error if redis is not available. But also the hooks itself didn't catch the case.

What I need is:
- don't throw error if redis connection not possible (either on startup or at runtime)
- reconnect if redis is available
- don't block requests if redis not available and return uncached response instead

Therefore I've implemented a cache strategy, catch it in the hooks (`if (!client) {}`) and added some console.log
Tests are included as well.

Closes https://github.com/idealley/feathers-hooks-rediscache/issues/58

@idealley it would be great if you can review this on the weekend, too. 

If both of my PRs are merged I'm able to use your hooks in production in a much much better way :)
